### PR TITLE
Skip Magnet test, and test Civet CI

### DIFF
--- a/test/tests/magnets/tests
+++ b/test/tests/magnets/tests
@@ -12,5 +12,6 @@
     exodiff = 'Larmor_stable_USLLG_test.e'
     max_parallel = 1
     max_threads = 1
+    skip = "Possible deprecated code"
   [../]
 []


### PR DESCRIPTION
Testing Civet CI.
Skipping the failing test. I don't know why it is failing. So we
probably should not merge this on a whim.