### PR TITLE
Convert MeshModifiers to MeshGenerators

### DIFF
--- a/test/tests/bismuth_iron_oxide/BFO_P-A-u_PBC_rigid_global_test.i
+++ b/test/tests/bismuth_iron_oxide/BFO_P-A-u_PBC_rigid_global_test.i
@@ -1,21 +1,21 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 3
-  nx = 4
-  ny = 4
-  nz = 4
-  xmin = -1.0
-  xmax = 1.0
-  ymin = -1.0
-  ymax = 1.0
-  zmin = -1.0
-  zmax = 1.0
-  elem_type = HEX8
-[]
-
-[MeshModifiers]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 4
+    ny = 4
+    nz = 4
+    xmin = -1.0
+    xmax = 1.0
+    ymin = -1.0
+    ymax = 1.0
+    zmin = -1.0
+    zmax = 1.0
+    elem_type = HEX8
+  []
   [./cnode]
-    type = AddExtraNodeset
+    input = gen
+    type = ExtraNodesetGenerator
     coord = '0.0 0.0 0.0'
     new_boundary = 100
   [../]

--- a/test/tests/electrooptics/electrooptic_test.i
+++ b/test/tests/electrooptics/electrooptic_test.i
@@ -1,11 +1,12 @@
 
 [Mesh]
-  file = 6grains.e
-[]
-
-[MeshModifiers]
+  [file]
+    type = FileMeshGenerator
+    file = 6grains.e
+  []
   [./add_side_sets]
-    type = SideSetsFromNormals
+    input = file
+    type = SideSetsFromNormalsGenerator
     normals = '1  0  0
                0  0  1
                0  0  -1'

--- a/test/tests/pbc/pbc.i
+++ b/test/tests/pbc/pbc.i
@@ -1,22 +1,22 @@
 
 [Mesh]
-  type = GeneratedMesh
-  dim = 3
-  nx = 6
-  ny = 6
-  nz = 2
-  xmin = -6.0
-  xmax = 6.0
-  ymin = -6.0
-  ymax = 6.0
-  zmin = -2.0
-  zmax = 2.0
-  elem_type = HEX8
-[]
-
-[MeshModifiers]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 6
+    ny = 6
+    nz = 2
+    xmin = -6.0
+    xmax = 6.0
+    ymin = -6.0
+    ymax = 6.0
+    zmin = -2.0
+    zmax = 2.0
+    elem_type = HEX8
+  []
   [./cnode]
-    type = AddExtraNodeset
+    input = gen
+    type = ExtraNodesetGenerator
     coord = '-6.0 -6.0 -2.0'
     new_boundary = 100
   [../]

--- a/test/tests/photoelasticity/photoelastic_test.i
+++ b/test/tests/photoelasticity/photoelastic_test.i
@@ -1,11 +1,12 @@
 
 [Mesh]
-  file = 6grains.e
-[]
-
-[MeshModifiers]
+  [file]
+    type = FileMeshGenerator
+    file = 6grains.e
+  []
   [./add_side_sets]
-    type = SideSetsFromNormals
+    input = file
+    type = SideSetsFromNormalsGenerator
     normals = '1  0  0
                0  0  1
                0  0  -1'
@@ -357,7 +358,7 @@
   [../]
   [./photoelastic_tensor_1]
     type = ComputeElastoopticTensor
-    fill_method = symmetric21 #BTO is not symmetric21 FIX!! 
+    fill_method = symmetric21 #BTO is not symmetric21 FIX!!
     # Use BaTiO3, crystal symmetry P4mm.
     P_mnkl = '0.5 0.106 0.2 0.0 0.0 0.0 0.5 0.2 0.0 0.0 0.0 0.77 0.0 0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.1'
     euler_angle_1 = 0.0
@@ -399,7 +400,7 @@
   [../]
   [./photoelastic_tensor_2]
     type = ComputeElastoopticTensor
-    fill_method = symmetric21 #BTO is not symmetric21 FIX!! 
+    fill_method = symmetric21 #BTO is not symmetric21 FIX!!
     # Use BaTiO3, crystal symmetry P4mm.
     P_mnkl = '0.5 0.106 0.2 0.0 0.0 0.0 0.5 0.2 0.0 0.0 0.0 0.77 0.0 0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.1'
     euler_angle_1 = 12.0
@@ -442,7 +443,7 @@
   [../]
   [./photoelastic_tensor_3]
     type = ComputeElastoopticTensor
-    fill_method = symmetric21 #BTO is not symmetric21 FIX!! 
+    fill_method = symmetric21 #BTO is not symmetric21 FIX!!
     # Use BaTiO3, crystal symmetry P4mm.
     P_mnkl = '0.5 0.106 0.2 0.0 0.0 0.0 0.5 0.2 0.0 0.0 0.0 0.77 0.0 0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.1'
     euler_angle_1 = 1.0
@@ -484,7 +485,7 @@
   [../]
   [./photoelastic_tensor_4]
     type = ComputeElastoopticTensor
-    fill_method = symmetric21 #BTO is not symmetric21 FIX!! 
+    fill_method = symmetric21 #BTO is not symmetric21 FIX!!
     # Use BaTiO3, crystal symmetry P4mm.
     P_mnkl = '0.5 0.106 0.2 0.0 0.0 0.0 0.5 0.2 0.0 0.0 0.0 0.77 0.0 0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.1'
     euler_angle_1 = 100.0
@@ -526,7 +527,7 @@
   [../]
   [./photoelastic_tensor_5]
     type = ComputeElastoopticTensor
-    fill_method = symmetric21 #BTO is not symmetric21 FIX!! 
+    fill_method = symmetric21 #BTO is not symmetric21 FIX!!
     # Use BaTiO3, crystal symmetry P4mm.
     P_mnkl = '0.5 0.106 0.2 0.0 0.0 0.0 0.5 0.2 0.0 0.0 0.0 0.77 0.0 0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.1'
     euler_angle_1 = 200.0
@@ -568,7 +569,7 @@
   [../]
   [./photoelastic_tensor_6]
     type = ComputeElastoopticTensor
-    fill_method = symmetric21 #BTO is not symmetric21 FIX!! 
+    fill_method = symmetric21 #BTO is not symmetric21 FIX!!
     # Use BaTiO3, crystal symmetry P4mm.
     P_mnkl = '0.5 0.106 0.2 0.0 0.0 0.0 0.5 0.2 0.0 0.0 0.0 0.77 0.0 0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.1'
     euler_angle_1 = 110.0


### PR DESCRIPTION
MeshModifiers have been deprecated for 15 months and are becoming a
maintenance burden, so we're trying to get them out of our testing
system.

Refs idaholab/moose#13814