### PR TITLE
Adjust contact info and warning for users using OLD implementations (which stay due to CI, old work)

### DIFF
--- a/examples/domain_walls/BTO_90wall_T298K.i
+++ b/examples/domain_walls/BTO_90wall_T298K.i
@@ -411,13 +411,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/domain_walls/BTO_wall_T298K.i
+++ b/examples/domain_walls/BTO_wall_T298K.i
@@ -409,13 +409,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/films/PTOfilm_e12_T298K_E0.i
+++ b/examples/films/PTOfilm_e12_T298K_E0.i
@@ -497,13 +497,15 @@
     block = '1'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/films/PZTfilm_e12_T298K_E0.i
+++ b/examples/films/PZTfilm_e12_T298K_E0.i
@@ -499,13 +499,15 @@
     block = '1'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/monodomain/BTO_monodomain_Tdef.i
+++ b/examples/monodomain/BTO_monodomain_Tdef.i
@@ -451,13 +451,15 @@ a111temp = a111def
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/monodomain/PTO_monodomain_Tdef.i
+++ b/examples/monodomain/PTO_monodomain_Tdef.i
@@ -449,13 +449,15 @@ a1temp = a1def
     prop_values = '175.0 79.4 111.1'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/monodomain/PZT_monodomain_Tdef.i
+++ b/examples/monodomain/PZT_monodomain_Tdef.i
@@ -438,13 +438,15 @@ a1temp = a1def
     block = '0'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/examples/other/PTO_E0.i
+++ b/examples/other/PTO_E0.i
@@ -308,13 +308,15 @@
     block = '3'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/include/auxkernels/AFDWallEnergyDensity.h
+++ b/include/auxkernels/AFDWallEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/AFMEasyPlaneAnisotropyEnergyDensity.h
+++ b/include/auxkernels/AFMEasyPlaneAnisotropyEnergyDensity.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef AFMEASYPLANEANISOTROPYENERGYDENSITY_H

--- a/include/auxkernels/AFMExchangeStiffnessEnergyDensity.h
+++ b/include/auxkernels/AFMExchangeStiffnessEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/AFMSingleIonCubicSixthAnisotropyEnergyDensity.h
+++ b/include/auxkernels/AFMSingleIonCubicSixthAnisotropyEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/AFMSpinCurrentLLdot.h
+++ b/include/auxkernels/AFMSpinCurrentLLdot.h
@@ -18,6 +18,7 @@
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef AFMSPINCURRENTLLDOT_H
 #define AFMSPINCURRENTLLDOT_H
 

--- a/include/auxkernels/AFMSpinCurrentLMdot.h
+++ b/include/auxkernels/AFMSpinCurrentLMdot.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef AFMSPINCURRENTLMDOT_H
 #define AFMSPINCURRENTLMDOT_H
 

--- a/include/auxkernels/AFMSpinCurrentMLdot.h
+++ b/include/auxkernels/AFMSpinCurrentMLdot.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef AFMSPINCURRENTMLDOT_H
 #define AFMSPINCURRENTMLDOT_H
 

--- a/include/auxkernels/AFMSpinCurrentMMdot.h
+++ b/include/auxkernels/AFMSpinCurrentMMdot.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef AFMSPINCURRENTMMDOT_H
 #define AFMSPINCURRENTMMDOT_H
 

--- a/include/auxkernels/AFMSublatticeSuperexchangeEnergyDensity.h
+++ b/include/auxkernels/AFMSublatticeSuperexchangeEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/AFMTotalEnergyDensity.h
+++ b/include/auxkernels/AFMTotalEnergyDensity.h
@@ -18,6 +18,7 @@
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef AFMTOTALENERGYDENSITY_H
 #define AFMTOTALENERGYDENSITY_H
 

--- a/include/auxkernels/AngleBetweenTwoVectors.h
+++ b/include/auxkernels/AngleBetweenTwoVectors.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef ANGLEBETWEENTWOVECTORS_H
 #define ANGLEBETWEENTWOVECTORS_H
 

--- a/include/auxkernels/BandGapAuxTiO2.h
+++ b/include/auxkernels/BandGapAuxTiO2.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/BandGapAuxZnOwRot.h
+++ b/include/auxkernels/BandGapAuxZnOwRot.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/Birefringence.h
+++ b/include/auxkernels/Birefringence.h
@@ -18,6 +18,7 @@
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef BIREFRINGENCE_H
 #define BIREFRINGENCE_H
 

--- a/include/auxkernels/BulkEnergyDensity.h
+++ b/include/auxkernels/BulkEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ChangeInRefractiveIndexElectro.h
+++ b/include/auxkernels/ChangeInRefractiveIndexElectro.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ChangeInRefractiveIndexWithPolar.h
+++ b/include/auxkernels/ChangeInRefractiveIndexWithPolar.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/DemagFieldAux.h
+++ b/include/auxkernels/DemagFieldAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/DemagFieldAuxPML.h
+++ b/include/auxkernels/DemagFieldAuxPML.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/DivP.h
+++ b/include/auxkernels/DivP.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ElasticEnergyDensity.h
+++ b/include/auxkernels/ElasticEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ElectricFluxTensor.h
+++ b/include/auxkernels/ElectricFluxTensor.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef ElectricFluxTensor_H
 #define ElectricFluxTensor_H
 

--- a/include/auxkernels/ElectrostrictiveCouplingEnergyDensity.h
+++ b/include/auxkernels/ElectrostrictiveCouplingEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ElectrostrictiveEnergyDensity.h
+++ b/include/auxkernels/ElectrostrictiveEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ExchangeFieldAux.h
+++ b/include/auxkernels/ExchangeFieldAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/FourierHeat.h
+++ b/include/auxkernels/FourierHeat.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef FourierHeat_H
 #define FourierHeat_H
 

--- a/include/auxkernels/HarmonicFieldAux.h
+++ b/include/auxkernels/HarmonicFieldAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/HeatFluxTensor.h
+++ b/include/auxkernels/HeatFluxTensor.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef HeatFluxTensor_H
 #define HeatFluxTensor_H
 

--- a/include/auxkernels/HoleDensityAux.h
+++ b/include/auxkernels/HoleDensityAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/IsotropicTEMaterialElecFlux.h
+++ b/include/auxkernels/IsotropicTEMaterialElecFlux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/IsotropicTEMaterialHeatFlux.h
+++ b/include/auxkernels/IsotropicTEMaterialHeatFlux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/JacobiansBulkEnergy.h
+++ b/include/auxkernels/JacobiansBulkEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/JacobiansRotoBulkEnergy.h
+++ b/include/auxkernels/JacobiansRotoBulkEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/JacobiansRotopolarCoupledEnergy.h
+++ b/include/auxkernels/JacobiansRotopolarCoupledEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/MagneticExchangeEnergyDensityCart.h
+++ b/include/auxkernels/MagneticExchangeEnergyDensityCart.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/MicroforceBulkEnergy.h
+++ b/include/auxkernels/MicroforceBulkEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/MicroforceElectrostaticEnergy.h
+++ b/include/auxkernels/MicroforceElectrostaticEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/MicroforceRotopolarCoupledDistortEnergy.h
+++ b/include/auxkernels/MicroforceRotopolarCoupledDistortEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/MicroforceRotopolarCoupledPolarEnergy.h
+++ b/include/auxkernels/MicroforceRotopolarCoupledPolarEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/MicroforceWallEnergy.h
+++ b/include/auxkernels/MicroforceWallEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/PolarOpticChangeInRefractiveIndex.h
+++ b/include/auxkernels/PolarOpticChangeInRefractiveIndex.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/PontryaginDensity.h
+++ b/include/auxkernels/PontryaginDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/QuasistaticFieldAux.h
+++ b/include/auxkernels/QuasistaticFieldAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/RefractiveIndex.h
+++ b/include/auxkernels/RefractiveIndex.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ReworkedRefractiveIndex.h
+++ b/include/auxkernels/ReworkedRefractiveIndex.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef REWORKEDREFRACTIVEINDEX_H

--- a/include/auxkernels/RotoPolarCouplingEnergyDensity.h
+++ b/include/auxkernels/RotoPolarCouplingEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/SDBulkEnergyDensity.h
+++ b/include/auxkernels/SDBulkEnergyDensity.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/SphericalCoordinateVector.h
+++ b/include/auxkernels/SphericalCoordinateVector.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef SPHERICALCOORDINATEVECTOR_H
 #define SPHERICALCOORDINATEVECTOR_H
 

--- a/include/auxkernels/SurfaceChargeP.h
+++ b/include/auxkernels/SurfaceChargeP.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/TensorPressureAux.h
+++ b/include/auxkernels/TensorPressureAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ThermoelectricZTAux.h
+++ b/include/auxkernels/ThermoelectricZTAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/TimeDependentFieldAux.h
+++ b/include/auxkernels/TimeDependentFieldAux.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/Transformed111Order.h
+++ b/include/auxkernels/Transformed111Order.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/TransformedMicroforceRotostrictiveCouplingEnergy.h
+++ b/include/auxkernels/TransformedMicroforceRotostrictiveCouplingEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/auxkernels/ValueAux.h
+++ b/include/auxkernels/ValueAux.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef VALUEAUX_H
 #define VALUEAUX_H
 

--- a/include/auxkernels/VectorDiffOrSum.h
+++ b/include/auxkernels/VectorDiffOrSum.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef VECTORDIFFORSUM_H
 #define VECTORDIFFORSUM_H
 

--- a/include/auxkernels/VectorMag.h
+++ b/include/auxkernels/VectorMag.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/bcs/CoupledDirichletBC.h
+++ b/include/bcs/CoupledDirichletBC.h
@@ -1,16 +1,23 @@
-/****************************************************************/
-/*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
-/*                   ALL RIGHTS RESERVED                        */
-/*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
-/*                                                              */
-/*            See COPYRIGHT for full restrictions               */
-/****************************************************************/
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
 
 #ifndef COUPLEDDIRICHLETBC_H
 #define COUPLEDDIRICHLETBC_H

--- a/include/bcs/ElectronCurrentDensityBC.h
+++ b/include/bcs/ElectronCurrentDensityBC.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef ELECTRONCURRENTDENSITYBC_H
 #define ELECTRONCURRENTDENSITYBC_H
 

--- a/include/bcs/HoleCurrentDensityBC.h
+++ b/include/bcs/HoleCurrentDensityBC.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef HOLECURRENTDENSITYBC_H
 #define HOLECURRENTDENSITYBC_H
 

--- a/include/functions/S3DFourierNoise.h
+++ b/include/functions/S3DFourierNoise.h
@@ -17,9 +17,9 @@
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
-   //adapted from FourierNoise.C [credit to D. Schwen (INL)]
-
 **/
+
+// adapted from FourierNoise.C [credit to D. Schwen (INL)]
 
 #pragma once
 

--- a/include/functions/SDFourierNoise.h
+++ b/include/functions/SDFourierNoise.h
@@ -17,9 +17,9 @@
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
-   //adapted from FourierNoise.C [credit to D. Schwen (INL)]
-
 **/
+
+// adapted from FourierNoise.C [credit to D. Schwen (INL)]
 
 #pragma once
 

--- a/include/ics/FluctuationsIC.h
+++ b/include/ics/FluctuationsIC.h
@@ -1,4 +1,4 @@
-/**
+/*
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
@@ -15,7 +15,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
-   and be sure to track new changes at bitbucket.org/mesoscience/ferret
+   and be sure to track new changes at github.com/mangerij/ferret
 
 **/
 

--- a/include/ics/RandomConstrainedVectorFieldIC.h
+++ b/include/ics/RandomConstrainedVectorFieldIC.h
@@ -1,4 +1,4 @@
-/**
+/*
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
@@ -15,7 +15,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
-   and be sure to track new changes at bitbucket.org/mesoscience/ferret
+   and be sure to track new changes at github.com/mangerij/ferret
 
 **/
 

--- a/include/interfacekernels/InterfaceEquality.h
+++ b/include/interfacekernels/InterfaceEquality.h
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/include/kernels/AFDWall2EnergyDerivative.h
+++ b/include/kernels/AFDWall2EnergyDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFDWallEnergyDerivative.h
+++ b/include/kernels/AFDWallEnergyDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMEasyPlaneAnisotropy.h
+++ b/include/kernels/AFMEasyPlaneAnisotropy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMEasyPlaneAnisotropySC.h
+++ b/include/kernels/AFMEasyPlaneAnisotropySC.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMHomogeneousSublatticeExchange.h
+++ b/include/kernels/AFMHomogeneousSublatticeExchange.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMInteractionCartLLHConst.h
+++ b/include/kernels/AFMInteractionCartLLHConst.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMLocalSublatticeExchangeCartLL.h
+++ b/include/kernels/AFMLocalSublatticeExchangeCartLL.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMSingleIonCubicSixthAnisotropy.h
+++ b/include/kernels/AFMSingleIonCubicSixthAnisotropy.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef AFMSINGLEIONCUBICSIXTHANISOTROPY_H

--- a/include/kernels/AFMSingleIonCubicSixthAnisotropySC.h
+++ b/include/kernels/AFMSingleIonCubicSixthAnisotropySC.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMSublatticeAnisotropy.h
+++ b/include/kernels/AFMSublatticeAnisotropy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMSublatticeDMInteraction.h
+++ b/include/kernels/AFMSublatticeDMInteraction.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AFMSublatticeDMInteractionSC.h
+++ b/include/kernels/AFMSublatticeDMInteractionSC.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/AnisotropyCartLL.h
+++ b/include/kernels/AnisotropyCartLL.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/BulkEnergyDerivativeEighth.h
+++ b/include/kernels/BulkEnergyDerivativeEighth.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/BulkEnergyDerivativeSixth.h
+++ b/include/kernels/BulkEnergyDerivativeSixth.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/BulkEnergyDerivativeSixthCoupledT.h
+++ b/include/kernels/BulkEnergyDerivativeSixthCoupledT.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/CarrierCon.h
+++ b/include/kernels/CarrierCon.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef CARRIERCON_H
 #define CARRIERCON_H
 

--- a/include/kernels/CarrierInt.h
+++ b/include/kernels/CarrierInt.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef CARRIERINT_H
 #define CARRIERINT_H
 

--- a/include/kernels/CarrierRec.h
+++ b/include/kernels/CarrierRec.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef CARRIERREC_H
 #define CARRIERREC_H
 

--- a/include/kernels/ConstField.h
+++ b/include/kernels/ConstField.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/CorrectedElectrostrictiveCouplingPolarDerivative.h
+++ b/include/kernels/CorrectedElectrostrictiveCouplingPolarDerivative.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef CORRECTEDELECTROSTRICTIVECOUPLINGPOLARDERIVATIVE_H

--- a/include/kernels/DepolEnergy.h
+++ b/include/kernels/DepolEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/DivCurrentV.h
+++ b/include/kernels/DivCurrentV.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/ElecCurrent.h
+++ b/include/kernels/ElecCurrent.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/ElecGen.h
+++ b/include/kernels/ElecGen.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/ElectrostrictiveCouplingDispDerivative.h
+++ b/include/kernels/ElectrostrictiveCouplingDispDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/ElectrostrictiveCouplingPDerivative.h
+++ b/include/kernels/ElectrostrictiveCouplingPDerivative.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef ELECTROSTRICTIVECOUPLINGPDERIVATIVE_H

--- a/include/kernels/ElectrostrictiveCouplingPolarDerivative.h
+++ b/include/kernels/ElectrostrictiveCouplingPolarDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/ElectrostrictiveCouplingPolarDerivativeRefactor.h
+++ b/include/kernels/ElectrostrictiveCouplingPolarDerivativeRefactor.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef ELECTROSTRICTIVECOUPLINGPOLARDERIVATIVEREFACTOR_H

--- a/include/kernels/ElectrostrictiveCouplingPolarDerivativeTEST.h
+++ b/include/kernels/ElectrostrictiveCouplingPolarDerivativeTEST.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/ExchangeCartLL.h
+++ b/include/kernels/ExchangeCartLL.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/FerroelectricCouplingP.h
+++ b/include/kernels/FerroelectricCouplingP.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/FerroelectricCouplingX.h
+++ b/include/kernels/FerroelectricCouplingX.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/FluctuationKernel.h
+++ b/include/kernels/FluctuationKernel.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/HeatFlowElectricT.h
+++ b/include/kernels/HeatFlowElectricT.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/HoleCurrent.h
+++ b/include/kernels/HoleCurrent.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/HoleGen.h
+++ b/include/kernels/HoleGen.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef HOLEGEN_H
 #define HOLEGEN_H
 

--- a/include/kernels/InPlaneSusceptibilityDerivative.h
+++ b/include/kernels/InPlaneSusceptibilityDerivative.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef INPLANESUSCEPTIBILITYDERIVATIVE_H

--- a/include/kernels/InteractionCartLL.h
+++ b/include/kernels/InteractionCartLL.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/LocalConservedLangevinNoise.h
+++ b/include/kernels/LocalConservedLangevinNoise.h
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/include/kernels/LocalLangevinNoise.h
+++ b/include/kernels/LocalLangevinNoise.h
@@ -1,20 +1,25 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
-//* This file is part of the MOOSE framework
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/include/kernels/LongitudinalLLB.h
+++ b/include/kernels/LongitudinalLLB.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/MagHStrongCart.h
+++ b/include/kernels/MagHStrongCart.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/MagHStrongSublatticesCart.h
+++ b/include/kernels/MagHStrongSublatticesCart.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/MasterExchangeCartLLG.h
+++ b/include/kernels/MasterExchangeCartLLG.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/MasterInteractionCartLLG.h
+++ b/include/kernels/MasterInteractionCartLLG.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/MasterInteractionCartLLGHConst.h
+++ b/include/kernels/MasterInteractionCartLLGHConst.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/MasterLongitudinalLLB.h
+++ b/include/kernels/MasterLongitudinalLLB.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/PolarElectricEStrong.h
+++ b/include/kernels/PolarElectricEStrong.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/RotoBulkEnergyDerivativeEighthAlt.h
+++ b/include/kernels/RotoBulkEnergyDerivativeEighthAlt.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/RotoPolarCoupledEnergyPolarDerivativeAlt.h
+++ b/include/kernels/RotoPolarCoupledEnergyPolarDerivativeAlt.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/RotostrictiveCouplingDistortDerivative.h
+++ b/include/kernels/RotostrictiveCouplingDistortDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/SDBulkEnergyDerivativeEighth.h
+++ b/include/kernels/SDBulkEnergyDerivativeEighth.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/SecondTimeDerivativeScaled.h
+++ b/include/kernels/SecondTimeDerivativeScaled.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/SeebeckEffect.h
+++ b/include/kernels/SeebeckEffect.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/TensorDivCurrentV.h
+++ b/include/kernels/TensorDivCurrentV.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/TensorHeatFlowElectricT.h
+++ b/include/kernels/TensorHeatFlowElectricT.h
@@ -14,10 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #ifndef TENSORHEATFLOWELECTRICT_H
 #define TENSORHEATFLOWELECTRICT_H
 

--- a/include/kernels/ThermalDiffusion.h
+++ b/include/kernels/ThermalDiffusion.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/TimeDerivativeScaled.h
+++ b/include/kernels/TimeDerivativeScaled.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/Transformed111ElectrostrictiveCouplingDispDerivative.h
+++ b/include/kernels/Transformed111ElectrostrictiveCouplingDispDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/Transformed111ElectrostrictiveCouplingPolarDerivative.h
+++ b/include/kernels/Transformed111ElectrostrictiveCouplingPolarDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/Transformed111KernelOp3.h
+++ b/include/kernels/Transformed111KernelOp3.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/Transformed111KernelOp3Alt.h
+++ b/include/kernels/Transformed111KernelOp3Alt.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/Transformed111RotostrictiveCouplingDistortDerivative.h
+++ b/include/kernels/Transformed111RotostrictiveCouplingDistortDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/UniaxialAFMSublattice.h
+++ b/include/kernels/UniaxialAFMSublattice.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/kernels/WallEnergyDerivative.h
+++ b/include/kernels/WallEnergyDerivative.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeDeltaIndicatrix.h
+++ b/include/materials/ComputeDeltaIndicatrix.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeDeltaIndicatrixElectro.h
+++ b/include/materials/ComputeDeltaIndicatrixElectro.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeDeltaIndicatrixElectroBase.h
+++ b/include/materials/ComputeDeltaIndicatrixElectroBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeElastoopticTensor.h
+++ b/include/materials/ComputeElastoopticTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeElastoopticTensorBase.h
+++ b/include/materials/ComputeElastoopticTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeElectricalConductivityTDepTensor.h
+++ b/include/materials/ComputeElectricalConductivityTDepTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeElectricalConductivityTensor.h
+++ b/include/materials/ComputeElectricalConductivityTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeElectricalConductivityTensorBase.h
+++ b/include/materials/ComputeElectricalConductivityTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeElectrostrictiveTensor.h
+++ b/include/materials/ComputeElectrostrictiveTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeFerroelectricStrain.h
+++ b/include/materials/ComputeFerroelectricStrain.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeIndicatrix.h
+++ b/include/materials/ComputeIndicatrix.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeIndicatrixBase.h
+++ b/include/materials/ComputeIndicatrixBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputePiezoTensor.h
+++ b/include/materials/ComputePiezoTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputePiezostrictiveTensor.h
+++ b/include/materials/ComputePiezostrictiveTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputePolarOpticTensor.h
+++ b/include/materials/ComputePolarOpticTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputePolarOpticTensorBase.h
+++ b/include/materials/ComputePolarOpticTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedElastoopticTensorBase.h
+++ b/include/materials/ComputeRotatedElastoopticTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedElectricalConductivityTensorBase.h
+++ b/include/materials/ComputeRotatedElectricalConductivityTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedElectroopticTensorBase.h
+++ b/include/materials/ComputeRotatedElectroopticTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedElectrostrictiveTensorBase.h
+++ b/include/materials/ComputeRotatedElectrostrictiveTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedGCoeffTensorBase.h
+++ b/include/materials/ComputeRotatedGCoeffTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedPiezoTensorBase.h
+++ b/include/materials/ComputeRotatedPiezoTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedPiezostrictiveTensorBase.h
+++ b/include/materials/ComputeRotatedPiezostrictiveTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedSeebeckTensorBase.h
+++ b/include/materials/ComputeRotatedSeebeckTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeRotatedThermalConductivityTensorBase.h
+++ b/include/materials/ComputeRotatedThermalConductivityTensorBase.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef COMPUTEROTATEDTHERMALCONDUCTIVITYTENSORBASE_H
 #define COMPUTEROTATEDTHERMALCONDUCTIVITYTENSORBASE_H
 

--- a/include/materials/ComputeSeebeckTDepTensor.h
+++ b/include/materials/ComputeSeebeckTDepTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeSeebeckTensor.h
+++ b/include/materials/ComputeSeebeckTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeSeebeckTensorBase.h
+++ b/include/materials/ComputeSeebeckTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeSpontaneousRotostrictiveStrain.h
+++ b/include/materials/ComputeSpontaneousRotostrictiveStrain.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeThermalConductivityTDepTensor.h
+++ b/include/materials/ComputeThermalConductivityTDepTensor.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #ifndef COMPUTETHERMALCONDUCTIVITYTDEPTENSOR_H
 #define COMPUTETHERMALCONDUCTIVITYTDEPTENSOR_H
 

--- a/include/materials/ComputeThermalConductivityTensor.h
+++ b/include/materials/ComputeThermalConductivityTensor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ComputeThermalConductivityTensorBase.h
+++ b/include/materials/ComputeThermalConductivityTensorBase.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <mangeri@fzu.cz>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/materials/ThermoelectricMaterial.h
+++ b/include/materials/ThermoelectricMaterial.h
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #pragma once
 
 #include "Material.h"

--- a/include/postprocessors/AFMEasyPlaneAnisotropyEnergy.h
+++ b/include/postprocessors/AFMEasyPlaneAnisotropyEnergy.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef AFMEASYPLANEANISOTROPYENERGY_H

--- a/include/postprocessors/AFMHomogeneousSublatticeExchangeEnergy.h
+++ b/include/postprocessors/AFMHomogeneousSublatticeExchangeEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/AFMSingleIonAnisotropyAltEnergy.h
+++ b/include/postprocessors/AFMSingleIonAnisotropyAltEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/AFMSublatticeAnisotropyAltEnergy.h
+++ b/include/postprocessors/AFMSublatticeAnisotropyAltEnergy.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef AFMSUBLATTICEANISOTROPYALTENERGY_H

--- a/include/postprocessors/AFMSublatticeAnisotropyEnergy.h
+++ b/include/postprocessors/AFMSublatticeAnisotropyEnergy.h
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #ifndef AFMSUBLATTICEANISOTROPYENERGY_H

--- a/include/postprocessors/AFMSublatticeSuperexchangeEnergy.h
+++ b/include/postprocessors/AFMSublatticeSuperexchangeEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/BulkEnergyEighth.h
+++ b/include/postprocessors/BulkEnergyEighth.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/CorrectedElectrostrictiveCouplingEnergy.h
+++ b/include/postprocessors/CorrectedElectrostrictiveCouplingEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/ElasticEnergy.h
+++ b/include/postprocessors/ElasticEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/ElectrostrictiveCouplingEnergy.h
+++ b/include/postprocessors/ElectrostrictiveCouplingEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/ElectrostrictiveCouplingEnergyRefactor.h
+++ b/include/postprocessors/ElectrostrictiveCouplingEnergyRefactor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/ElectrostrictiveCouplingPEnergy.h
+++ b/include/postprocessors/ElectrostrictiveCouplingPEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/ElectrostrictiveEnergy.h
+++ b/include/postprocessors/ElectrostrictiveEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/EnergyRatePostprocessor.h
+++ b/include/postprocessors/EnergyRatePostprocessor.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/InhomogeneousBulkEnergy.h
+++ b/include/postprocessors/InhomogeneousBulkEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/MagneticExcessLLBEnergy.h
+++ b/include/postprocessors/MagneticExcessLLBEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/MagnetostaticEnergyCart.h
+++ b/include/postprocessors/MagnetostaticEnergyCart.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/MasterMagneticExchangeEnergy.h
+++ b/include/postprocessors/MasterMagneticExchangeEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/RotopolarCouplingEnergy.h
+++ b/include/postprocessors/RotopolarCouplingEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/postprocessors/WallEnergy.h
+++ b/include/postprocessors/WallEnergy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/include/transfers/MultiAppAddTransfer.h
+++ b/include/transfers/MultiAppAddTransfer.h
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/include/transfers/MultiAppFieldAddTransfer.h
+++ b/include/transfers/MultiAppFieldAddTransfer.h
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/include/userobjects/BoundaryIntegralFMM.h
+++ b/include/userobjects/BoundaryIntegralFMM.h
@@ -1,3 +1,26 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//   The FMM boundary condition is contributed by X. Jiang <xikaij@imech.ac.cn> see J. Chem. Phys. 145, 6, (2016)
+
 #ifndef BOUNDARYINTEGRALFMM_H
 #define BOUNDARYINTEGRALFMM_H
 

--- a/src/action/ABO3CoupledPhaseFieldAction.C
+++ b/src/action/ABO3CoupledPhaseFieldAction.C
@@ -19,6 +19,8 @@
 
 **/
 
+// This piece of code is WIP
+
 #include "ABO3CoupledPhaseFieldAction.h"
 #include "Factory.h"
 #include "Parser.h"

--- a/src/action/LKScalarAction.C
+++ b/src/action/LKScalarAction.C
@@ -19,6 +19,8 @@
 
 **/
 
+//This piece of code is WIP
+
 #include "LKScalarAction.h"
 #include "Factory.h"
 #include "Parser.h"

--- a/src/auxkernels/AFDWallEnergyDensity.C
+++ b/src/auxkernels/AFDWallEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/AFMEasyPlaneAnisotropyEnergyDensity.C
+++ b/src/auxkernels/AFMEasyPlaneAnisotropyEnergyDensity.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "AFMEasyPlaneAnisotropyEnergyDensity.h"

--- a/src/auxkernels/AFMExchangeStiffnessEnergyDensity.C
+++ b/src/auxkernels/AFMExchangeStiffnessEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/AFMSingleIonCubicSixthAnisotropyEnergyDensity.C
+++ b/src/auxkernels/AFMSingleIonCubicSixthAnisotropyEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/AFMSpinCurrentMLdot.C
+++ b/src/auxkernels/AFMSpinCurrentMLdot.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/AFMSublatticeSuperexchangeEnergyDensity.C
+++ b/src/auxkernels/AFMSublatticeSuperexchangeEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/AngleBetweenTwoVectors.C
+++ b/src/auxkernels/AngleBetweenTwoVectors.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published _var2y[_qp]
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 

--- a/src/auxkernels/BandGapAuxZnO.C
+++ b/src/auxkernels/BandGapAuxZnO.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/BandGapAuxZnOwRot.C
+++ b/src/auxkernels/BandGapAuxZnOwRot.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/BulkEnergyDensity.C
+++ b/src/auxkernels/BulkEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ChangeInRefractiveIndexElectro.C
+++ b/src/auxkernels/ChangeInRefractiveIndexElectro.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ChangeInRefractiveIndexWithGCoeffPolar.C
+++ b/src/auxkernels/ChangeInRefractiveIndexWithGCoeffPolar.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ChangeInRefractiveIndexWithPolar.C
+++ b/src/auxkernels/ChangeInRefractiveIndexWithPolar.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/DemagFieldAuxPML.C
+++ b/src/auxkernels/DemagFieldAuxPML.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/DivP.C
+++ b/src/auxkernels/DivP.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ElastoChangeInRefractiveIndex.C
+++ b/src/auxkernels/ElastoChangeInRefractiveIndex.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ElectricFluxTensor.C
+++ b/src/auxkernels/ElectricFluxTensor.C
@@ -11,10 +11,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ElectronDensity.C
+++ b/src/auxkernels/ElectronDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ElectrostrictiveCouplingEnergyDensity.C
+++ b/src/auxkernels/ElectrostrictiveCouplingEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ElectrostrictiveEnergyDensity.C
+++ b/src/auxkernels/ElectrostrictiveEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ExchangeFieldAux.C
+++ b/src/auxkernels/ExchangeFieldAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/HarmonicFieldAux.C
+++ b/src/auxkernels/HarmonicFieldAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/HeatFluxTensor.C
+++ b/src/auxkernels/HeatFluxTensor.C
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #include "HeatFluxTensor.h"
 #include "Material.h"
 #include "RankTwoTensor.h"

--- a/src/auxkernels/HoleDensityAux.C
+++ b/src/auxkernels/HoleDensityAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/IsotropicTEMaterialElecFlux.C
+++ b/src/auxkernels/IsotropicTEMaterialElecFlux.C
@@ -11,10 +11,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/IsotropicTEMaterialHeatFlux.C
+++ b/src/auxkernels/IsotropicTEMaterialHeatFlux.C
@@ -11,10 +11,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/JacobiansRotoBulkEnergy.C
+++ b/src/auxkernels/JacobiansRotoBulkEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/JacobiansRotopolarCoupledEnergy.C
+++ b/src/auxkernels/JacobiansRotopolarCoupledEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/MagneticExchangeEnergyDensityCart.C
+++ b/src/auxkernels/MagneticExchangeEnergyDensityCart.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/MicroforceElectrostrictiveCouplingEnergy.C
+++ b/src/auxkernels/MicroforceElectrostrictiveCouplingEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/MicroforceRotoBulkEnergy.C
+++ b/src/auxkernels/MicroforceRotoBulkEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/MicroforceRotopolarCoupledDistortEnergy.C
+++ b/src/auxkernels/MicroforceRotopolarCoupledDistortEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/MicroforceRotopolarCoupledPolarEnergy.C
+++ b/src/auxkernels/MicroforceRotopolarCoupledPolarEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/PontryaginDensity.C
+++ b/src/auxkernels/PontryaginDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/RefractiveIndex.C
+++ b/src/auxkernels/RefractiveIndex.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ReworkedRefractiveIndex.C
+++ b/src/auxkernels/ReworkedRefractiveIndex.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "ReworkedRefractiveIndex.h"

--- a/src/auxkernels/RotoBulkEnergyDensity.C
+++ b/src/auxkernels/RotoBulkEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/RotoPolarCouplingEnergyDensity.C
+++ b/src/auxkernels/RotoPolarCouplingEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/RotostrictiveCouplingEnergyDensity.C
+++ b/src/auxkernels/RotostrictiveCouplingEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/SDBulkEnergyDensity.C
+++ b/src/auxkernels/SDBulkEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/SphericalCoordinateVector.C
+++ b/src/auxkernels/SphericalCoordinateVector.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published _var2y[_qp]
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/SurfaceChargeP.C
+++ b/src/auxkernels/SurfaceChargeP.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/TensorPressureAux.C
+++ b/src/auxkernels/TensorPressureAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ThermoelectricZTAux.C
+++ b/src/auxkernels/ThermoelectricZTAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/TimeDependentFieldAux.C
+++ b/src/auxkernels/TimeDependentFieldAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/Transform111Order.C
+++ b/src/auxkernels/Transform111Order.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/Transformed110Order.C
+++ b/src/auxkernels/Transformed110Order.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/Transformed111Order.C
+++ b/src/auxkernels/Transformed111Order.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/TransformedMicroforceRotostrictiveCouplingEnergy.C
+++ b/src/auxkernels/TransformedMicroforceRotostrictiveCouplingEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/ValueAux.C
+++ b/src/auxkernels/ValueAux.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/VectorDiffOrSum.C
+++ b/src/auxkernels/VectorDiffOrSum.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/VectorMag.C
+++ b/src/auxkernels/VectorMag.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/auxkernels/WallEnergyDensity.C
+++ b/src/auxkernels/WallEnergyDensity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/bcs/ElectronCurrentDensityBC.C
+++ b/src/bcs/ElectronCurrentDensityBC.C
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #include "ElectronCurrentDensityBC.h"
 
 registerMooseObject("FerretApp", ElectronCurrentDensityBC);

--- a/src/bcs/HoleCurrentDensityBC.C
+++ b/src/bcs/HoleCurrentDensityBC.C
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #include "HoleCurrentDensityBC.h"
 
 registerMooseObject("FerretApp", HoleCurrentDensityBC);

--- a/src/functions/S3DFourierNoise.C
+++ b/src/functions/S3DFourierNoise.C
@@ -17,9 +17,9 @@
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
-   //adapted from FourierNoise.C [credit to D. Schwen (INL)]
-
 **/
+
+// adapted from FourierNoise.C [credit to D. Schwen (INL)]
 
 #include "S3DFourierNoise.h"
 #include "MooseRandom.h"

--- a/src/functions/SDFourierNoise.C
+++ b/src/functions/SDFourierNoise.C
@@ -17,9 +17,9 @@
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
-   //adapted from FourierNoise.C [credit to D. Schwen (INL)]
-
 **/
+
+// adapted from FourierNoise.C [credit to D. Schwen (INL)]
 
 #include "SDFourierNoise.h"
 #include "MooseRandom.h"

--- a/src/interfacekernels/InterfaceEquality.C
+++ b/src/interfacekernels/InterfaceEquality.C
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is derived from a part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/src/kernels/AFDWall2EnergyDerivative.C
+++ b/src/kernels/AFDWall2EnergyDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFDWallEnergyDerivative.C
+++ b/src/kernels/AFDWallEnergyDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMEasyPlaneAnisotropy.C
+++ b/src/kernels/AFMEasyPlaneAnisotropy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMEasyPlaneAnisotropySC.C
+++ b/src/kernels/AFMEasyPlaneAnisotropySC.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMInteractionCartLLHConst.C
+++ b/src/kernels/AFMInteractionCartLLHConst.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMLocalSublatticeExchangeCartLL.C
+++ b/src/kernels/AFMLocalSublatticeExchangeCartLL.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMSingleIonCubicSixthAnisotropy.C
+++ b/src/kernels/AFMSingleIonCubicSixthAnisotropy.C
@@ -18,6 +18,7 @@
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
+
 #include "AFMSingleIonCubicSixthAnisotropy.h"
 #include "libmesh/utility.h"
 

--- a/src/kernels/AFMSingleIonCubicSixthAnisotropySC.C
+++ b/src/kernels/AFMSingleIonCubicSixthAnisotropySC.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMSublatticeAnisotropy.C
+++ b/src/kernels/AFMSublatticeAnisotropy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMSublatticeDMInteraction.C
+++ b/src/kernels/AFMSublatticeDMInteraction.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMSublatticeDMInteractionSC.C
+++ b/src/kernels/AFMSublatticeDMInteractionSC.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AFMSublatticeSuperexchange.C
+++ b/src/kernels/AFMSublatticeSuperexchange.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/AnisotropicElectrostatics.C
+++ b/src/kernels/AnisotropicElectrostatics.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/BulkEnergyDerivativeEighth.C
+++ b/src/kernels/BulkEnergyDerivativeEighth.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/CarrierCon.C
+++ b/src/kernels/CarrierCon.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/CarrierInt.C
+++ b/src/kernels/CarrierInt.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/CarrierRec.C
+++ b/src/kernels/CarrierRec.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ConstField.C
+++ b/src/kernels/ConstField.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/CorrectedElectrostrictiveCouplingPolarDerivative.C
+++ b/src/kernels/CorrectedElectrostrictiveCouplingPolarDerivative.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "CorrectedElectrostrictiveCouplingPolarDerivative.h"

--- a/src/kernels/DivCurrentV.C
+++ b/src/kernels/DivCurrentV.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ElecCurrent.C
+++ b/src/kernels/ElecCurrent.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Electrostatics.C
+++ b/src/kernels/Electrostatics.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ElectrostrictiveCouplingDispDerivative.C
+++ b/src/kernels/ElectrostrictiveCouplingDispDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ElectrostrictiveCouplingPDerivative.C
+++ b/src/kernels/ElectrostrictiveCouplingPDerivative.C
@@ -11,10 +11,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ElectrostrictiveCouplingPolarDerivative.C
+++ b/src/kernels/ElectrostrictiveCouplingPolarDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ElectrostrictiveCouplingPolarDerivativeRefactor.C
+++ b/src/kernels/ElectrostrictiveCouplingPolarDerivativeRefactor.C
@@ -11,10 +11,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ElectrostrictiveCouplingPolarDerivativeTEST.C
+++ b/src/kernels/ElectrostrictiveCouplingPolarDerivativeTEST.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/ExchangeCartLL.C
+++ b/src/kernels/ExchangeCartLL.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/FerroelectricCouplingP.C
+++ b/src/kernels/FerroelectricCouplingP.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/FerroelectricCouplingX.C
+++ b/src/kernels/FerroelectricCouplingX.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/FluctuationKernel.C
+++ b/src/kernels/FluctuationKernel.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/HeatFlowElectricT.C
+++ b/src/kernels/HeatFlowElectricT.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/HoleCurrent.C
+++ b/src/kernels/HoleCurrent.C
@@ -14,11 +14,10 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
-
 
 #include "HoleCurrent.h"
 

--- a/src/kernels/HoleGen.C
+++ b/src/kernels/HoleGen.C
@@ -14,11 +14,10 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
-
 
 #include "HoleGen.h"
 

--- a/src/kernels/InPlaneSusceptibilityDerivative.C
+++ b/src/kernels/InPlaneSusceptibilityDerivative.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "InPlaneSusceptibilityDerivative.h"

--- a/src/kernels/InteractionCartLL.C
+++ b/src/kernels/InteractionCartLL.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/LocalConservedLangevinNoise.C
+++ b/src/kernels/LocalConservedLangevinNoise.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/LocalLangevinNoise.C
+++ b/src/kernels/LocalLangevinNoise.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/LongitudinalLLB.C
+++ b/src/kernels/LongitudinalLLB.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/MagHStrongCart.C
+++ b/src/kernels/MagHStrongCart.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/MagHStrongSublatticesCart.C
+++ b/src/kernels/MagHStrongSublatticesCart.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/MagneticPMLCart.C
+++ b/src/kernels/MagneticPMLCart.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/MasterAnisotropyCartLLG.C
+++ b/src/kernels/MasterAnisotropyCartLLG.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/MasterExchangeCartLLG.C
+++ b/src/kernels/MasterExchangeCartLLG.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the ter___Ms of the GNU General Public License as published by
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/MasterInteractionCartLLGHConst.C
+++ b/src/kernels/MasterInteractionCartLLGHConst.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/PiezoelectricStrainCharge.C
+++ b/src/kernels/PiezoelectricStrainCharge.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/PolarElectricPStrong.C
+++ b/src/kernels/PolarElectricPStrong.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/PolarElectricPStrongEConst.C
+++ b/src/kernels/PolarElectricPStrongEConst.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/RotatedBulkEnergyDerivativeSixth.C
+++ b/src/kernels/RotatedBulkEnergyDerivativeSixth.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/RotoBulkEnergyDerivativeEighthAlt.C
+++ b/src/kernels/RotoBulkEnergyDerivativeEighthAlt.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/RotoPolarCoupledEnergyDistortDerivativeAlt.C
+++ b/src/kernels/RotoPolarCoupledEnergyDistortDerivativeAlt.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/RotoPolarCoupledEnergyPolarDerivativeAlt.C
+++ b/src/kernels/RotoPolarCoupledEnergyPolarDerivativeAlt.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/RotostrictiveCouplingDispDerivative.C
+++ b/src/kernels/RotostrictiveCouplingDispDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/SeebeckEffect.C
+++ b/src/kernels/SeebeckEffect.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/TensorDivCurrentV.C
+++ b/src/kernels/TensorDivCurrentV.C
@@ -14,12 +14,12 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
 
-//Code by Dharma Raj Basaula 2021
+// - Code by Dharma Raj Basaula 2021, see Acta Mater., 228, 117743, 2022
 
 #include "TensorDivCurrentV.h"
 // #include "HeatConduction.h"

--- a/src/kernels/TensorHeatFlowElectricT.C
+++ b/src/kernels/TensorHeatFlowElectricT.C
@@ -19,7 +19,8 @@
 
 **/
 
-//Code by Dharma Raj Basaula 2021
+
+// - Code by Dharma Raj Basaula 2021, see Acta Mater., 228, 117743, 2022
 
 #include "TensorHeatFlowElectricT.h"
 #include "Material.h"

--- a/src/kernels/ThermalConductivity.C
+++ b/src/kernels/ThermalConductivity.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Transformed110Kernel.C
+++ b/src/kernels/Transformed110Kernel.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Transformed111ElectrostrictiveCouplingDispDerivative.C
+++ b/src/kernels/Transformed111ElectrostrictiveCouplingDispDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Transformed111ElectrostrictiveCouplingPolarDerivative.C
+++ b/src/kernels/Transformed111ElectrostrictiveCouplingPolarDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Transformed111KernelOp3.C
+++ b/src/kernels/Transformed111KernelOp3.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Transformed111RotostrictiveCouplingDispDerivative.C
+++ b/src/kernels/Transformed111RotostrictiveCouplingDispDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/UniaxialAFMSublattice.C
+++ b/src/kernels/UniaxialAFMSublattice.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/kernels/Wall2EnergyDerivative.C
+++ b/src/kernels/Wall2EnergyDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
@@ -26,7 +26,7 @@ registerMooseObject("FerretApp", Wall2EnergyDerivative);
 InputParameters Wall2EnergyDerivative::validParams()
 {
   InputParameters params = Kernel::validParams();
-  params.addClassDescription("Calculates a residual contribution due to the variation w.r.t polarization of the gradient energy. This Kernel needs to be used in conjunction with WallEnergyDerivative!");
+  params.addClassDescription("Calculates a residual contribution due to the variation w.r.t polarization of the gradient energy. This Kernel should be used in conjunction with WallEnergyDerivative!");
   params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction in OP space this kernel acts in (e.g. for unrotated functionals 0 for q_x, 1 for q_y, 2 for q_z).");
   params.addRequiredCoupledVar("polar_x", "The x component of the polarization");
   params.addRequiredCoupledVar("polar_y", "The y component of the polarization");

--- a/src/kernels/WallEnergyDerivative.C
+++ b/src/kernels/WallEnergyDerivative.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/
@@ -26,7 +26,7 @@ registerMooseObject("FerretApp", WallEnergyDerivative);
 InputParameters WallEnergyDerivative::validParams()
 {
   InputParameters params = Kernel::validParams();
-  params.addClassDescription("Calculates a residual contribution due to the variation w.r.t polarization of the gradient energy. This Kernel needs to be used in conjunction with Wall2EnergyDerivative!");
+  params.addClassDescription("Calculates a residual contribution due to the variation w.r.t polarization of the gradient energy. This Kernel should be used in conjunction with Wall2EnergyDerivative!");
   params.addRequiredParam<unsigned int>("component", "An integer corresponding to the direction in order parameter space this kernel acts in (e.g. for unrotated functionals 0 for q_x, 1 for q_y, 2 for q_z).");
   params.addRequiredCoupledVar("polar_x", "The x component of the polarization");
   params.addRequiredCoupledVar("polar_y", "The y component of the polarization");

--- a/src/materials/ComputeDeltaIndicatrixElectro.C
+++ b/src/materials/ComputeDeltaIndicatrixElectro.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeElastoopticTensor.C
+++ b/src/materials/ComputeElastoopticTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeElastoopticTensorBase.C
+++ b/src/materials/ComputeElastoopticTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeElectricalConductivityTDepTensor.C
+++ b/src/materials/ComputeElectricalConductivityTDepTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeElectricalConductivityTensorBase.C
+++ b/src/materials/ComputeElectricalConductivityTensorBase.C
@@ -1,3 +1,23 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
 
 #include "ComputeElectricalConductivityTensorBase.h"
 

--- a/src/materials/ComputeElectroopticTensorBase.C
+++ b/src/materials/ComputeElectroopticTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeElectrostrictiveTensor.C
+++ b/src/materials/ComputeElectrostrictiveTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeElectrostrictiveTensorBase.C
+++ b/src/materials/ComputeElectrostrictiveTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeFerroelectricStrain.C
+++ b/src/materials/ComputeFerroelectricStrain.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeIndicatrix.C
+++ b/src/materials/ComputeIndicatrix.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeIndicatrixBase.C
+++ b/src/materials/ComputeIndicatrixBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputePiezoTensor.C
+++ b/src/materials/ComputePiezoTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputePiezostrictiveTensorBase.C
+++ b/src/materials/ComputePiezostrictiveTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputePolarOpticGCoeffTensor.C
+++ b/src/materials/ComputePolarOpticGCoeffTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputePolarOpticTensor.C
+++ b/src/materials/ComputePolarOpticTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeRotatedElastoopticTensorBase.C
+++ b/src/materials/ComputeRotatedElastoopticTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeRotatedGCoeffTensorBase.C
+++ b/src/materials/ComputeRotatedGCoeffTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeRotatedIndicatrixBase.C
+++ b/src/materials/ComputeRotatedIndicatrixBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeRotatedPiezoTensorBase.C
+++ b/src/materials/ComputeRotatedPiezoTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeRotatedPiezostrictiveTensorBase.C
+++ b/src/materials/ComputeRotatedPiezostrictiveTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeRotatedThermalConductivityTensorBase.C
+++ b/src/materials/ComputeRotatedThermalConductivityTensorBase.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeSeebeckTDepTensor.C
+++ b/src/materials/ComputeSeebeckTDepTensor.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeSeebeckTensor.C
+++ b/src/materials/ComputeSeebeckTensor.C
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #include "ComputeSeebeckTensor.h"
 #include "RotationTensor.h"
 #include "RankTwoTensor.h"

--- a/src/materials/ComputeSeebeckTensorBase.C
+++ b/src/materials/ComputeSeebeckTensorBase.C
@@ -1,3 +1,23 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
 
 #include "ComputeSeebeckTensorBase.h"
 

--- a/src/materials/ComputeSpontaneousRotostrictiveStrain.C
+++ b/src/materials/ComputeSpontaneousRotostrictiveStrain.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/materials/ComputeThermalConductivityTDepTensor.C
+++ b/src/materials/ComputeThermalConductivityTDepTensor.C
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #include "ComputeThermalConductivityTDepTensor.h"
 #include "RotationTensor.h"
 #include "RankTwoTensor.h"

--- a/src/materials/ComputeThermalConductivityTensor.C
+++ b/src/materials/ComputeThermalConductivityTensor.C
@@ -1,3 +1,24 @@
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
 #include "ComputeThermalConductivityTensor.h"
 #include "RotationTensor.h"
 #include "RankTwoTensor.h"

--- a/src/materials/ThermoelectricMaterials.C
+++ b/src/materials/ThermoelectricMaterials.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/AFMEasyPlaneAnisotropyEnergy.C
+++ b/src/postprocessors/AFMEasyPlaneAnisotropyEnergy.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "AFMEasyPlaneAnisotropyEnergy.h"

--- a/src/postprocessors/AFMExchangeStiffnessEnergy.C
+++ b/src/postprocessors/AFMExchangeStiffnessEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/AFMSingleIonAnisotropyEnergy.C
+++ b/src/postprocessors/AFMSingleIonAnisotropyEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/AFMSingleIonCubicSixthAnisotropyEnergy.C
+++ b/src/postprocessors/AFMSingleIonCubicSixthAnisotropyEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/AFMSublatticeAnisotropyAltEnergy.C
+++ b/src/postprocessors/AFMSublatticeAnisotropyAltEnergy.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "AFMSublatticeAnisotropyAltEnergy.h"

--- a/src/postprocessors/AFMSublatticeAnisotropyEnergy.C
+++ b/src/postprocessors/AFMSublatticeAnisotropyEnergy.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "AFMSublatticeAnisotropyEnergy.h"

--- a/src/postprocessors/AFMSublatticeDMIEnergy.C
+++ b/src/postprocessors/AFMSublatticeDMIEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/AFMSublatticeDMInteractionEnergy.C
+++ b/src/postprocessors/AFMSublatticeDMInteractionEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/AFMSublatticeSuperexchangeEnergy.C
+++ b/src/postprocessors/AFMSublatticeSuperexchangeEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/BulkEnergy.C
+++ b/src/postprocessors/BulkEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/CorrectedElectrostrictiveCouplingEnergy.C
+++ b/src/postprocessors/CorrectedElectrostrictiveCouplingEnergy.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/postprocessors/DomainVariantPopulation.C
+++ b/src/postprocessors/DomainVariantPopulation.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/ElectrostrictiveCouplingEnergyRefactor.C
+++ b/src/postprocessors/ElectrostrictiveCouplingEnergyRefactor.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/postprocessors/ElectrostrictiveCouplingPEnergy.C
+++ b/src/postprocessors/ElectrostrictiveCouplingPEnergy.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_qp] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/postprocessors/ElectrostrictiveEnergy.C
+++ b/src/postprocessors/ElectrostrictiveEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/MasterMagneticExchangeEnergy.C
+++ b/src/postprocessors/MasterMagneticExchangeEnergy.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/MasterMagneticZeemanEnergyCart.C
+++ b/src/postprocessors/MasterMagneticZeemanEnergyCart.C
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
 **/

--- a/src/postprocessors/RotostrictiveCouplingEnergy.C
+++ b/src/postprocessors/RotostrictiveCouplingEnergy.C
@@ -14,8 +14,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-   For help with FERRET please contact J. Mangeri <john.m.mangeri@gmail.com>
-   and be sure to track new changes at github.com/mangerij/ferret=
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
 
 **/
 

--- a/src/scalarkernels/ScalarBulkEnergyA.C
+++ b/src/scalarkernels/ScalarBulkEnergyA.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_antiferrodis_A_y[_i] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/scalarkernels/ScalarBulkEnergyP.C
+++ b/src/scalarkernels/ScalarBulkEnergyP.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_i] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/scalarkernels/ScalarElectrostrictiveEnergy.C
+++ b/src/scalarkernels/ScalarElectrostrictiveEnergy.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_i] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/scalarkernels/ScalarRotopolarEnergy.C
+++ b/src/scalarkernels/ScalarRotopolarEnergy.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_polar_y[_i] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/scalarkernels/ScalarRotostrictiveEnergy.C
+++ b/src/scalarkernels/ScalarRotostrictiveEnergy.C
@@ -11,7 +11,7 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a co_antiferrodis_A_y[_i] of the GNU General Public License
+   You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>

--- a/src/transfers/MultiAppAddTransfer.C
+++ b/src/transfers/MultiAppAddTransfer.C
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/src/transfers/MultiAppFieldAddTransfer.C
+++ b/src/transfers/MultiAppFieldAddTransfer.C
@@ -1,4 +1,25 @@
-//* This file is part of the MOOSE framework
+/*
+   This file is part of FERRET, an add-on module for MOOSE
+
+   FERRET is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
+   and be sure to track new changes at github.com/mangerij/ferret
+
+**/
+
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/src/userobjects/BoundaryIntegralFMM.C
+++ b/src/userobjects/BoundaryIntegralFMM.C
@@ -17,9 +17,9 @@
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
 
-   The FMM boundary condition is contributed by X. Jiang <xikaij@imech.ac.cn>
 **/
 
+//   The FMM boundary condition is contributed by X. Jiang <xikaij@imech.ac.cn> see J. Chem. Phys. 145, 6, (2016)
 
 #include "BoundaryIntegralFMM.h"
 #include <iostream>

--- a/src/userobjects/GlobalATiO3MaterialRVEUserObject.C
+++ b/src/userobjects/GlobalATiO3MaterialRVEUserObject.C
@@ -1,17 +1,22 @@
 /*
    This file is part of FERRET, an add-on module for MOOSE
+
    FERRET is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
    For help with FERRET please contact J. Mangeri <johnma@dtu.dk>
    and be sure to track new changes at github.com/mangerij/ferret
+
 **/
 
 #include "GlobalATiO3MaterialRVEUserObject.h"

--- a/src/userobjects/LocalConservedNoiseBase.C
+++ b/src/userobjects/LocalConservedNoiseBase.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the ter___Ms of the GNU General Public License as published by
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 
@@ -19,7 +19,7 @@
 
 **/
 
-//* This file is modified from part of the MOOSE framework
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/src/userobjects/LocalConservedNoiseInterface.C
+++ b/src/userobjects/LocalConservedNoiseInterface.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the ter___Ms of the GNU General Public License as published by
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 
@@ -19,7 +19,7 @@
 
 **/
 
-//* This file is modified from part of the MOOSE framework
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/src/userobjects/LocalConservedNormalNoise.C
+++ b/src/userobjects/LocalConservedNormalNoise.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the ter___Ms of the GNU General Public License as published by
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 
@@ -19,7 +19,7 @@
 
 **/
 
-//* This file is modified from part of the MOOSE framework
+//* This file is adapted from part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/src/userobjects/LocalConservedUniformNoise.C
+++ b/src/userobjects/LocalConservedUniformNoise.C
@@ -2,7 +2,7 @@
    This file is part of FERRET, an add-on module for MOOSE
 
    FERRET is free software: you can redistribute it and/or modify
-   it under the ter___Ms of the GNU General Public License as published by
+   it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
 

--- a/test/tests/auxkernels/microforce.i
+++ b/test/tests/auxkernels/microforce.i
@@ -343,6 +343,17 @@
     prop_names = 'C11 C12 C44'
     prop_values = '175 79.4 111.1'
   [../]
+  
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/test/tests/auxkernels/surface_charge.i
+++ b/test/tests/auxkernels/surface_charge.i
@@ -461,14 +461,6 @@
     prop_values = '10.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0'
     block = '1'
   [../]
-
-
-  ############################################
-  ##
-  ## add comments
-  ##
-  ############################################
-
   [./Landau_G_FE]
     type = GenericConstantMaterial
     prop_names = 'G110 G11_G110 G12_G110 G44_G110 G44P_G110'
@@ -489,13 +481,15 @@
     block = '1'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/coupled/PTOtest_2D.i
+++ b/test/tests/coupled/PTOtest_2D.i
@@ -97,6 +97,16 @@
     type = ComputeLinearElasticStress
   [../]
 
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+
   [./slab_ferroelectric]
     type = ComputeElectrostrictiveTensor
     Q_mnkl = '-0.089 0.026 0.026 -0.089 0.026 -0.089 -0.03375 -0.03375 -0.03375'

--- a/test/tests/coupled/PTOtest_3D.i
+++ b/test/tests/coupled/PTOtest_3D.i
@@ -119,6 +119,16 @@
     type = ComputeLinearElasticStress
   [../]
 
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+
   [./slab_ferroelectric]
     type = ComputeElectrostrictiveTensor
     Q_mnkl = '-0.089 0.026 0.026 -0.089 0.026 -0.089 -0.03375 -0.03375 -0.03375'

--- a/test/tests/dispersion/genDomain_PyEz.i
+++ b/test/tests/dispersion/genDomain_PyEz.i
@@ -399,13 +399,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/dispersion/genDomain_PzEz.i
+++ b/test/tests/dispersion/genDomain_PzEz.i
@@ -399,13 +399,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/dispersion/perturbBTO_PyEz.i
+++ b/test/tests/dispersion/perturbBTO_PyEz.i
@@ -326,13 +326,15 @@ amplitude = 1e-3
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/dispersion/perturbBTO_PzEz.i
+++ b/test/tests/dispersion/perturbBTO_PzEz.i
@@ -326,13 +326,15 @@ amplitude = 0.001
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/domain_wall/test_BTO_domain_wall.i
+++ b/test/tests/domain_wall/test_BTO_domain_wall.i
@@ -352,7 +352,17 @@
     prop_names = 'C11 C12 C44'
     prop_values = '275.0 179.0 54.3'
   [../]
-
+  
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/test/tests/electrooptics/BTO_monodomain_T298K_REF.i
+++ b/test/tests/electrooptics/BTO_monodomain_T298K_REF.i
@@ -516,13 +516,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/electrooptics/BTO_monodomain_T298K_REFnoEO.i
+++ b/test/tests/electrooptics/BTO_monodomain_T298K_REFnoEO.i
@@ -513,13 +513,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/film/PTO_film3_T298K.i
+++ b/test/tests/film/PTO_film3_T298K.i
@@ -458,13 +458,15 @@
     block = '1'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/film/PTO_film3_T298K_noP.i
+++ b/test/tests/film/PTO_film3_T298K_noP.i
@@ -431,13 +431,6 @@
     block = '1'
   [../]
 
-
-  ############################################
-  ##
-  ## add comments
-  ##
-  ############################################
-
   [./Landau_G_FE]
     type = GenericConstantMaterial
     prop_names = 'G110 G11_G110 G12_G110 G44_G110 G44P_G110'
@@ -458,13 +451,15 @@
     block = '1'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/ics/PTOtest_fluc.i
+++ b/test/tests/ics/PTOtest_fluc.i
@@ -120,7 +120,17 @@
   [./stress_1]
     type = ComputeLinearElasticStress
   [../]
-
+  
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./slab_ferroelectric]
     type = ComputeElectrostrictiveTensor
     Q_mnkl = '-0.089 0.026 0.026 -0.089 0.026 -0.089 -0.03375 -0.03375 -0.03375'

--- a/test/tests/landau_khalatnikov/LK_full_test.i
+++ b/test/tests/landau_khalatnikov/LK_full_test.i
@@ -43,6 +43,17 @@
   C12 = 45.5681
   C44 = 28.709
 
+
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   q11 = -5.89457
   q12 = -0.971881
   q44 = -2.01751

--- a/test/tests/msca/BFO_P0A0.i
+++ b/test/tests/msca/BFO_P0A0.i
@@ -687,6 +687,16 @@ h44 = 0.8e-3
     prop_values = '295.179 117.567 74.0701'
   [../]
 
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/test/tests/msca/BFO_dwP1A1_100.i
+++ b/test/tests/msca/BFO_dwP1A1_100.i
@@ -706,6 +706,16 @@ h44 = 0.8e-3
     prop_values = '295.179 117.567 74.0701'
   [../]
 
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/test/tests/pbc/bcc_pbc.i
+++ b/test/tests/pbc/bcc_pbc.i
@@ -321,13 +321,15 @@
     block = '3'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/test/tests/pbc/pbc.i
+++ b/test/tests/pbc/pbc.i
@@ -227,6 +227,17 @@
     prop_names = 'C11 C12 C44'
     prop_values = '175 79.4 111.1'
   [../]
+  
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/test/tests/topology/A_skyrm.i
+++ b/test/tests/topology/A_skyrm.i
@@ -299,13 +299,15 @@
     prop_values = '275.0 179.0 54.3'
   [../]
 
-  ##################################################
+  ##############################################################
   ##
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
   ##
-  ##################################################
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial

--- a/tutorial/BFO_dwP1A1_100.i
+++ b/tutorial/BFO_dwP1A1_100.i
@@ -689,6 +689,17 @@ h44 = 0.8e-3
     prop_names = 'C11 C12 C44'
     prop_values = '295.179 117.567 74.0701'
   [../]
+  
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/tutorial/BFO_homogeneous_PA.i
+++ b/tutorial/BFO_homogeneous_PA.i
@@ -684,6 +684,16 @@ h44 = 0.8e-3
     prop_values = '295.179 117.567 74.0701'
   [../]
 
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./mat_Q]
     type = GenericConstantMaterial
     prop_names = 'Q11 Q12 Q44'

--- a/tutorial/ferroelectric_domain_wall.i
+++ b/tutorial/ferroelectric_domain_wall.i
@@ -600,6 +600,16 @@
     global_strain_uo = global_strain_uo
   [../]
 
+  ##############################################################
+  ##
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
+  
   [./slab_ferroelectric]
     type = ComputeElectrostrictiveTensor
     Q_mnkl = '0.11 -0.045 -0.045 0.11 -0.045 0.11 0.029 0.029 0.029'

--- a/tutorial/film.i
+++ b/tutorial/film.i
@@ -645,13 +645,15 @@
     block = '1'
   [../]
 
-  ##################################################
-  ##=
-  ## NOTE: Sign convention in Ferret for the
-  ##        electrostrictive coeff. is multiplied by
-  ##        an overall factor of (-1)
+  ##############################################################
   ##
-  ##################################################
+  ## NOTE: Sign convention in **this implementation**
+  ##       for the electrostrictive coeff. is multiplied by
+  ##       an overall factor of (-1). Note that other elastic
+  ##       coupling Kernels/Materials in Ferret DO NOT have the 
+  ##       (-1) prefactor. Please be careful here.
+  ##
+  ###############################################################
 
   [./mat_Q]
     type = GenericConstantMaterial


### PR DESCRIPTION
Adjust contact info in headers and comments on OLD implementations and correct signs of the electrostrictive tensor coefficients in the NEW implementations that are not documented.

Note that the NEW implementation, that correctly does the thin film problem as well as is benchmarked to within floating point accuracy for analytical solutions for a variety of canonical perovskites is NOT documented at this present time. 